### PR TITLE
Fix error about core module path when use --no-default-features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ macro_rules! slice_as_array_transmute {
 #[cfg(not(feature="use_std"))]
 #[macro_export]
 macro_rules! slice_as_array_transmute {
-    ($slice:expr) => { ::core::mem::transmute($slice) }
+    ($slice:expr) => { core::mem::transmute($slice) }
 }
 
 


### PR DESCRIPTION
To ready to use this library on no_std, I run `cargo build --no-default-features`.

### Expected

There is no error and it builds correctly.

### Result

But there are errors as below.

```
error[E0433]: failed to resolve: maybe a missing crate `core`?
   --> src/lib.rs:79:26
    |
79  |     ($slice:expr) => { ::core::mem::transmute($slice) }
    |                          ^^^^ maybe a missing crate `core`?
...
173 |         let xs_prefix: &[u32; 3] = slice_as_array!(&xs[1..4], [u32; 3]).expect("Length mismatch");
    |                                    ------------------------------------ in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

```

### How to fix

Fix core path.

```rs
-    ($slice:expr) => { ::core::mem::transmute($slice) }
+    ($slice:expr) => { core::mem::transmute($slice) }
```